### PR TITLE
Add [compat] and remove Compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 1.0
   - 1
   - nightly
 notifications:

--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,13 @@ uuid = "d04cd5f8-5917-4006-ac6f-d139328806a7"
 version = "0.1.0"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+
+[compat]
+FileIO = "1"
+Images = "0.22"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/AndorSIF.jl
+++ b/src/AndorSIF.jl
@@ -1,6 +1,6 @@
 module AndorSIF
 
-using Images, FileIO, Compat
+using Images, FileIO
 
 # SIF.jl, adds an imread function for Andor .sif images
 # 2013 Ronald S. Rock, Jr.


### PR DESCRIPTION
https://github.com/JuliaRegistries/General/pull/19264 highlighted the need for `[compat]` entries. I also removed the dependence on Compat since that is clearly from an earlier era.