### PR TITLE
fixed dimension order

### DIFF
--- a/src/AndorSIF.jl
+++ b/src/AndorSIF.jl
@@ -197,7 +197,7 @@ function FileIO.load(fs::Stream{format"AndorSIF"})
 
     offset = position(io) # start of the actual pixel data, 32-bit float, little-endian
 
-    pixelmatrix = Array{Gray{Float32}}(undef, height, width, frames)
+    pixelmatrix = Array{Gray{Float32}}(undef, width, height, frames)
     read!(io, pixelmatrix)
     properties = Dict(
         :ixon => ixon,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ img_2d = load(testfile_2d)
 img_1d = load(testfile_1d)
 
 @test size(img_2d) == (512, 512, 1)
-@test size(img_1d) == (1, 512, 1)
+@test size(img_1d) == (512, 1, 1)
 @test img_1d[1:2] == [789.0, 783.0]
 @test img_1d[end-1:end] == [765.0, 768.0]
 @test img_1d.ixon["exposure_time"] == 5.0


### PR DESCRIPTION
Turned out the file is saved pixel-row for row, we read it in column-first. To make it work with `read!(io, pixelmatrix)` we have to flip the dimensions.