### PR TITLE
Update dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ version = "0.1.1"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 
 [compat]
 FileIO = "1"
-Images = "0.22, 0.23"
+ImageCore = "0.8, 0.9, 0.10"
+ImageMetadata = "0.9"
 julia = "1"
 
 [extras]

--- a/src/AndorSIF.jl
+++ b/src/AndorSIF.jl
@@ -1,6 +1,6 @@
 module AndorSIF
 
-using Images, FileIO
+using ImageCore, ImageMetadata, FileIO
 
 # SIF.jl, adds an imread function for Andor .sif images
 # 2013 Ronald S. Rock, Jr.


### PR DESCRIPTION
* Reduce dependencies to `ImageCore` and `ImageMetadata` instead of the full `Images`

  The only thing we need from `ImageCore` was `Gray` from `ColorTypes` but since `ImageCore` is a dependency of `ImageMetadata` anyway this doesn't make any difference.

* Make sure we are compatible with the latest versions.

Started this mainly since I noticed that AndorSIF was pinning Images (and many other packages) to an old version....
